### PR TITLE
modify mkdocs-material to new repo.

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -15,3 +15,38 @@ starting org.apache.spark.sql.connect.service.SparkConnectServer, logging to...
 $ tail -1 logs/spark-jacek-org.apache.spark.sql.connect.service.SparkConnectServer-1-Jaceks-Mac-mini.local.out
 ... Spark Connect server started.
 ```
+
+Use Spark Connect for interactive analysis:
+
+```bash
+./bin/pyspark --remote "sc://localhost"
+```
+
+And you will notice that the PySpark shell welcome message tells you that you have connected to Spark using Spark Connect:
+
+```python
+Client connected to the Spark Connect server at localhost
+```
+
+ Check the Spark session type:
+
+```python
+SparkSession available as 'spark'.
+>>> type(spark)
+<class 'pyspark.sql.connect.session.SparkSession'>
+```
+
+Now you can run PySpark code in the shell to see Spark Connect in action:
+
+```python
+>>> columns = ["id","name"]
+>>> data = [(1,"Sarah"),(2,"Maria")]
+>>> df = spark.createDataFrame(data).toDF(*columns)
+>>> df.show()
++---+-----+
+| id| name|
++---+-----+
+|  1|Sarah|
+|  2|Maria|
++---+-----+
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material.git
+git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
 mkdocs-minify-plugin>=0.3.0
 mkdocs-git-revision-date-localized-plugin>=0.8
 mkdocs-git-revision-date-plugin>=0.3.1


### PR DESCRIPTION
Material for MkDocs has moved to https://github.com/squidfunk/mkdocs-material, use git clone and pip install:
```
git clone https://github.com/squidfunk/mkdocs-material.git

pip install -e mkdocs-material
```
or
```
pip install -r requirements.txt
```